### PR TITLE
rewrite to use sdformat

### DIFF
--- a/bindings/pydrake/visualization/test/model_visualizer_reload_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_reload_test.py
@@ -58,7 +58,7 @@ class TestModelVisualizerReload(unittest.TestCase):
 
         # Run once. If a reload() happened, the diagram will have changed out.
         # Use a non-default position so we can check that it is maintained.
-        original_q = [1.0, 2.0]
+        original_q = [1.0, 2.0] + [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         dut.Run(position=original_q, loop_once=True)
         self.assertNotEqual(id(orig_diagram), id(dut._diagram))
 

--- a/bindings/pydrake/visualization/test/model_visualizer_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_test.py
@@ -176,7 +176,7 @@ class TestModelVisualizer(unittest.TestCase):
             # SDFormat world file with multiple models.
             "package://drake/manipulation/util/test/"
             + "simple_world_with_two_models.sdf",
-            # GLTF file.
+            # glTF file.
             "package://drake_models/veggies/assets/"
             + "yellow_bell_pepper_no_stem_low.gltf"
         ]
@@ -193,6 +193,13 @@ class TestModelVisualizer(unittest.TestCase):
 
     def test_model_from_url(self):
         url = "package://drake/multibody/benchmarks/acrobot/acrobot.sdf"
+        dut = mut.ModelVisualizer()
+        dut.AddModels(url=url)
+        dut.Run(loop_once=True)
+
+    def test_model_from_gltf_url(self):
+        url = ("package://drake_models/veggies/assets/"
+               + "yellow_bell_pepper_no_stem_low.gltf")
         dut = mut.ModelVisualizer()
         dut.AddModels(url=url)
         dut.Run(loop_once=True)


### PR DESCRIPTION
- Now there are joint sliders to the object around.
- Now it's visible to the RGBD sensor.
- No need to treat reloading as a special case.
- Smoother path to having Parser consume glTF directly.